### PR TITLE
added create2 to Nft rewards deployer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,6 @@ OWNER_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f
 # - gnosis: https://gnosis.publicnode.com
 RPC_URL="http://127.0.0.1:8545"
 
+#this is an example salt that is used to deploy the contract on the same address in different
+#make sure to change the salt if u need to redeploy the same contract in the same chain
+SALT="69420"

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,4 @@ OWNER_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f
 # - anvil: http://127.0.0.1:8545
 # - gnosis: https://gnosis.publicnode.com
 RPC_URL="http://127.0.0.1:8545"
+

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
 https://gnosisscan.io/address/0xAa1bfC0e51969415d64d6dE74f27CDa0587e645b
 
 ## How it works
+
 1. Minter signs an off-chain mint request for a target user
 2. Target user takes the minter's signature and [mints](https://github.com/ubiquity/nft-rewards/blob/f7e1e2c093d33ba23f316da2267983fc6d8bf572/src/NftReward.sol#L123) a new NFT on-chain
 
 ## How to deploy
 
 1. Create a new `.env` file and set environment variables, example:
+
 ```
 # API key from a code contract verifying service.
 # May be empty for a local anvil deployment.
@@ -40,9 +42,16 @@ OWNER_PRIVATE_KEY="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f
 # - anvil: http://127.0.0.1:8545
 # - gnosis: https://gnosis.publicnode.com
 RPC_URL="http://127.0.0.1:8545"
+
+#this is an example salt that is used to deploy the contract on the same address in different
+#make sure to change the salt if u need to redeploy the same contract in the same chain
+SALT="69420"
+
 ```
+
 2. (Optional) Run a local anvil instance via the `anvil` command (if you want to deploy locally)
 3. Run one of the deployment scripts:
+
 ```
 yarn deploy:dev # deploys contracts WITHOUT source code verifying
 yarn deploy:prod # deploys contracts WITH source code verifying (`ETHERSCAN_API_KEY` env variable must be set)

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,3 +4,4 @@ out = "out"
 libs = ["lib"]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options
+

--- a/script/Deploy001_NftReward.s.sol
+++ b/script/Deploy001_NftReward.s.sol
@@ -13,14 +13,15 @@ contract Deploy001_NftReward is Script {
         string memory nftTokenName = vm.envString("NFT_TOKEN_NAME");
         string memory nftTokenSymbol = vm.envString("NFT_TOKEN_SYMBOL");
         uint256 ownerPrivateKey = vm.envUint("OWNER_PRIVATE_KEY");
-
+        // bytes32 salt = vm.envBytes32("SALT");
         address ownerAddress = vm.addr(ownerPrivateKey);
 
         // start sending owner transactions
         vm.startBroadcast(ownerPrivateKey);
-
+        //Enter the your salt here
+        bytes32 salt = "694204353";
         // deploy NftReward
-        nftReward = new NftReward(
+        nftReward = new NftReward{salt: salt}(
             nftTokenName, // token name
             nftTokenSymbol, // token symbol
             ownerAddress, // owner address

--- a/script/Deploy001_NftReward.s.sol
+++ b/script/Deploy001_NftReward.s.sol
@@ -13,13 +13,12 @@ contract Deploy001_NftReward is Script {
         string memory nftTokenName = vm.envString("NFT_TOKEN_NAME");
         string memory nftTokenSymbol = vm.envString("NFT_TOKEN_SYMBOL");
         uint256 ownerPrivateKey = vm.envUint("OWNER_PRIVATE_KEY");
-        // bytes32 salt = vm.envBytes32("SALT");
+        bytes32 salt = bytes32(bytes(vm.envString("SALT")));
         address ownerAddress = vm.addr(ownerPrivateKey);
 
         // start sending owner transactions
         vm.startBroadcast(ownerPrivateKey);
-        //Enter the your salt here
-        bytes32 salt = "694204353";
+
         // deploy NftReward
         nftReward = new NftReward{salt: salt}(
             nftTokenName, // token name


### PR DESCRIPTION
fixes #2 , 
added create2 in the [deployement script](https://github.com/ubiquity/nft-rewards/blob/development/script/Deploy001_NftReward.s.sol) so that the same contract can we deployed on all chains.

The salt is provided in the deployment script.